### PR TITLE
adding conferences sub directory

### DIFF
--- a/cloud-native/conferences/nodeconf.eu-2021.md
+++ b/cloud-native/conferences/nodeconf.eu-2021.md
@@ -1,0 +1,1 @@
+# Nodeconf.EU Remote 2021

--- a/cloud-native/conferences/nodeconf.eu-2021.md
+++ b/cloud-native/conferences/nodeconf.eu-2021.md
@@ -1,1 +1,0 @@
-# Nodeconf.EU Remote 2021

--- a/conferences/nodeconf.eu-2021.md
+++ b/conferences/nodeconf.eu-2021.md
@@ -1,0 +1,16 @@
+# Nodeconf.EU Remote 2021
+
+This is a 3 part workshop covering:
+
+
+### Cloud Native concepts - [link](../cloud-native/README.md)
+
+Self-paced workshop - Instructions provided as [GitHub README](../cloud-native/README.md)
+
+### Building your first REST API - LINK
+
+Self-paced workshop - Instructions provided as GitHub README
+
+### Full stack deployment - [link](https://developers.redhat.com/developer-sandbox/activities/deploying-full-stack-javascript-applications-to-the-sandbox/part1)
+
+Sandbox based interactive tutorial


### PR DESCRIPTION
This adds a sub directory for the conferences that this workshop is used in.  For easier public linking.

Still waiting on the REST API section to be PR'd in before we can add the link, #11 

Also not sure if this sub directory should be at the root or inside the cloud-native directory